### PR TITLE
fix(cli): use stderr for logging to avoid protocol interference

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "bin": {
     "containerization-assist-mcp": "./dist/apps/cli.js",
-    "ck-mcp": "./dist/apps/cli.js"
+    "ca-mcp": "./dist/apps/cli.js"
   },
   "files": [
     "dist/**/*",

--- a/src/application/tools/ops/registry.ts
+++ b/src/application/tools/ops/registry.ts
@@ -19,7 +19,7 @@ export type { ToolDescriptor, ToolContext } from '../tool-types.js';
 export class ToolRegistry {
   private tools = new Map<string, ToolDescriptor>();
   private toolList: Array<{ name: string; description?: string; inputSchema?: unknown }> = [];
-  private server!: McpServer; 
+  private server!: McpServer;
 
   constructor(
     private readonly services: Services,
@@ -36,11 +36,14 @@ export class ToolRegistry {
 
   private logToolExecution(toolName: string, params: unknown): void {
     // Log to our logger instead of server.log to avoid stdout interference
-    this.logger.info({
-      tool: toolName,
-      params: this.sanitizeParams(params) as any,
-      timestamp: new Date().toISOString(),
-    }, 'Tool execution started');
+    this.logger.info(
+      {
+        tool: toolName,
+        params: this.sanitizeParams(params) as any,
+        timestamp: new Date().toISOString(),
+      },
+      'Tool execution started',
+    );
   }
 
   private sanitizeParams(params: unknown): unknown {
@@ -452,7 +455,10 @@ export class ToolRegistry {
             if (this.server != null && module.default?.handler != null) {
               this.registerTool(module.default as any);
               this.logger.debug({ module: name, type: 'mcp' }, 'Tool loaded');
-            } else if (module.default?.handler != null || (module.default as any)?.execute != null) {
+            } else if (
+              module.default?.handler != null ||
+              (module.default as any)?.execute != null
+            ) {
               // Fallback to basic registration for testing
               this.register(module.default);
               this.logger.debug({ module: name, type: 'basic' }, 'Tool loaded');

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -109,7 +109,7 @@ export const getConfigSummary = getConfigurationSummary;
  */
 export function logConfigSummaryIfDev(configInstance: ApplicationConfig): void {
   if (configInstance.server.nodeEnv === 'development' && configInstance.features.enableDebugLogs) {
-    console.log('Configuration loaded:', getConfigurationSummary(configInstance));
+    console.error('Configuration loaded:', getConfigurationSummary(configInstance));
   }
 }
 

--- a/src/infrastructure/logger.ts
+++ b/src/infrastructure/logger.ts
@@ -85,10 +85,13 @@ export function createPinoLogger(config?: PinoConfig): Logger {
     };
 
     if (config?.useStderr) {
-      return pino({
-        ...options,
-        transport: prettyTransport,
-      }, pino.destination(2)); // Force to stderr
+      return pino(
+        {
+          ...options,
+          transport: prettyTransport,
+        },
+        pino.destination(2),
+      ); // Force to stderr
     } else {
       return pino({
         ...options,


### PR DESCRIPTION
Redirect logging to stderr to prevent interference with the MCP protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tool listing grouped by category with clearer names/descriptions and totals; explicit “no tools” message.
  - Enhanced startup messages indicate HTTP port usage; improved diagnostics for validation, health checks, and shutdown.
- Documentation
  - Updated help text for listing tools to reference registered MCP tools.
- Chores
  - CLI alias change: use “ca-mcp”; “ck-mcp” removed. Existing “containerization-assist-mcp” remains.
- Refactor
  - All CLI operational output now prints to stderr for consistent, non-interfering streams; wording polished across prompts and status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->